### PR TITLE
Add Image Nexus breakdown and mobile spacing fix

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1216,6 +1216,10 @@ section:nth-child(odd) .animate.scroll {
         width: 160px;
     }
 
+    .projects-content .progress h3 {
+        flex-direction: column;
+        gap: 0.4rem;
+    }
     .home-sci a {
         width: 38px;
         height: 38px;

--- a/index.html
+++ b/index.html
@@ -278,29 +278,6 @@
                 </div>
               </div>
               
-
-            <div class="projects-column">
-                <!-- <h3 class="title">Project 3<span class="animate scroll" style="--i:8;"></span></h3> -->
-                <div class="projects-box">
-                    <div class="projects-content">
-                    <a href="https://imagenexus.netlify.app/">
-                        <div class="progress">
-                            <h3>AI Integration <span>Hand of the Alchemist</span></h3>
-                            <div class="bar">
-                                <img src="/images/hota-portfolio-image.jpg" />
-                                <span></span></div>
-                                <p>An AI image generator website where users can create images and share them with others. Created using OpenAI's API.</p>
-                                <br>
-                                <p>Technologies employed: React, MongoDB, Express.js, Node.js, Tailwind CSS, OpenAI API </p>
-                            </a>
-                        </div>
-                </div>
-                
-                <span class="animate scroll" style="--i:3;"></span>
-            </div>
-        </div>
-
-            
             <div class="projects-column">
                 <!-- <h3 class="title">Project 2<span class="animate scroll" style="--i:5;"></span></h3> -->
                 
@@ -322,6 +299,29 @@
                         <span class="animate scroll" style="--i:3;"></span>
                     </div>
                 </div>
+
+            <div class="projects-column">
+                <!-- <h3 class="title">Project 3<span class="animate scroll" style="--i:8;"></span></h3> -->
+                <div class="projects-box">
+                    <div class="projects-content">
+                    <a href="/projects/imagenexus.html">
+                        <div class="progress">
+                            <h3>AI Integration <span>Image Nexus</span></h3>
+                            <div class="bar">
+                                <img src="/images/hota-portfolio-image.jpg" />
+                                <span></span></div>
+                                <p>Image Nexus is a retro-styled AI image generator mimicking the Mother computer terminal from the Alien films.</p>
+                                <br>
+                                <p>Technologies employed: React, MongoDB, Express.js, Node.js, Tailwind CSS, OpenAI API </p>
+                            </a>
+                        </div>
+                </div>
+                
+                <span class="animate scroll" style="--i:3;"></span>
+            </div>
+        </div>
+
+            
 
                 <div class="projects-column">
                     <!-- <h3 class="title">Project 1<span class="animate scroll" style="--i:2;"></span></h3> -->

--- a/projects/imagenexus.html
+++ b/projects/imagenexus.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Image Nexus – Project Breakdown</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body class="project-page">
+  <section class="project-breakdown">
+    <h1>Image Nexus</h1>
+    <p><a href="https://imagenexus.netlify.app/" target="_blank" class="cta-link">🌐 View Live Site</a></p>
+
+    <img src="/images/hota-portfolio-image.jpg" alt="Image Nexus screenshot" class="project-image" />
+
+    <h2>Overview</h2>
+    <p>Image Nexus is a retro-styled image generator designed to mimic the Mother computer terminal from the Alien film franchise. Users can create AI-generated images and share them with others.</p>
+
+    <h2>Technologies Used</h2>
+    <ul>
+      <li>React</li>
+      <li>MongoDB</li>
+      <li>Express.js</li>
+      <li>Node.js</li>
+      <li>Tailwind CSS</li>
+      <li>OpenAI API</li>
+    </ul>
+
+    <h2>Why I Built It</h2>
+    <p>I wanted to combine my love of classic sci-fi aesthetics with modern AI tools, creating a site that feels like accessing a futuristic mainframe.</p>
+
+    <h2>Challenges</h2>
+    <p>Capturing the vintage terminal look while keeping the interface responsive was tricky. Integrating the OpenAI API securely also required careful planning.</p>
+
+    <p class="back-link"><a href="/#projects">← Back to Portfolio</a></p>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rename "Hand of the Alchemist" project to **Image Nexus**
- move Carmilla project above Image Nexus on the portfolio page
- add a detailed `projects/imagenexus.html` page
- tweak mobile CSS so project headings stack on small screens

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c58f9ae6c83228dc5a4700974fee1