### PR TITLE
Fix mobile layout issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -82,6 +82,7 @@ body {
     font-size: 2.5rem;
     color: var(--text-color);
     font-weight: 600;
+    word-break: break-word;
 }
 
 .navbar {
@@ -547,6 +548,7 @@ span {
     position: relative;
     font-size: 1.6rem;
     margin: 2rem 0 3rem;
+    overflow-wrap: anywhere;
 }
 
 .btn-box.btns {
@@ -1207,6 +1209,10 @@ section:nth-child(odd) .animate.scroll {
         font-size: 50%;
     }
 
+    .logo {
+        font-size: 2rem;
+    }
+
     .home-content h1 {
         display: flex;
         flex-direction: column;
@@ -1259,6 +1265,16 @@ section:nth-child(odd) .animate.scroll {
         align-items: center;
         flex-direction: column;
         text-align: center;
+    }
+
+    .btn-box {
+        width: 100%;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .home-sci {
+        bottom: 2rem;
     }
 
     .home-content h1 {


### PR DESCRIPTION
## Summary
- allow the logo text to wrap
- prevent about section text overflow
- adjust logo size on small screens
- stack home buttons and tweak icon spacing when the screen is tiny

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c5c7b3d1883228a5173b60757a932