### PR TITLE
Fix mobile overlap and overflow issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -549,6 +549,7 @@ span {
     font-size: 1.6rem;
     margin: 2rem 0 3rem;
     overflow-wrap: anywhere;
+    padding: 0 1rem;
 }
 
 .btn-box.btns {
@@ -1220,6 +1221,8 @@ section:nth-child(odd) .animate.scroll {
 
     .home-sci {
         width: 160px;
+        position: static;
+        margin-top: 2rem;
     }
 
     .projects-content .progress h3 {
@@ -1274,7 +1277,8 @@ section:nth-child(odd) .animate.scroll {
     }
 
     .home-sci {
-        bottom: 2rem;
+        position: static;
+        margin-top: 2rem;
     }
 
     .home-content h1 {


### PR DESCRIPTION
## Summary
- adjust `.home-sci` for smaller screens so icons don't overlap with button links
- tweak `.home-sci` layout and added margin for 520px breakpoint
- allow about text to wrap with padding

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c5e2294dc8322bf603187105ca465