### PR TITLE
Fix header text for mobile and adjust section styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -85,6 +85,10 @@ body {
     word-break: break-word;
 }
 
+.logo-short {
+    display: none;
+}
+
 .navbar {
     position: relative;
 }
@@ -488,7 +492,7 @@ button {
     flex-direction: column;
     gap: 2rem;
     background: var(--second-bg-color);
-    padding-bottom: 6rem;
+    padding: 10rem 0 6rem;
 }
 
 .heading {
@@ -909,8 +913,8 @@ span {
 
 .contact {
     min-height: auto;
-    padding-bottom: 7rem;
     background: var(--second-bg-color);
+    padding: 10rem 0 7rem;
 }
 
 .contact h2 {
@@ -1213,6 +1217,14 @@ section:nth-child(odd) .animate.scroll {
 
     .logo {
         font-size: 2rem;
+    }
+
+    .logo-full {
+        display: none;
+    }
+
+    .logo-short {
+        display: inline;
     }
 
     .home-content h1 {

--- a/index.html
+++ b/index.html
@@ -18,7 +18,11 @@
     
     <!-- header design-->
     <header class="header">
-        <a href="#" class="logo">/users/seishin/myportfolio<span class="animate" style="--i:1;"></span></a>
+        <a href="#" class="logo">
+            <span class="logo-full">/users/seishin/myportfolio</span>
+            <span class="logo-short">../myportfolio</span>
+            <span class="animate" style="--i:1;"></span>
+        </a>
 
         <div class="bx bx-menu" id="menu-icon"><span class="animate" style="--i:2;"></span></div>
 


### PR DESCRIPTION
## Summary
- shorten header text on small screens using new `.logo-short`
- tweak about and contact section padding to span full width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c6619a10883228dda9d3da626d7ca